### PR TITLE
update signt_test algo

### DIFF
--- a/src/luminol/algorithms/anomaly_detector_algorithms/sign_test.py
+++ b/src/luminol/algorithms/anomaly_detector_algorithms/sign_test.py
@@ -96,7 +96,7 @@ class SignTest(AnomalyDetectorAlgorithm):
                                             self.scale * np.array(self.baseline_time_series.values),
                                             k=self.scan_window,
                                             conf=self.confidence,
-                                            alpha=float(self.percent_threshold) / 100,
+                                            alpha=self.scale * float(self.percent_threshold) / 100,
                                             offset=self.scale * self.offset)
     for (s, e), prob in anomalies:
       scores[s:e] = 100 * prob


### PR DESCRIPTION
use self.scale for alpha to make it consistent with offset. For example if we are detecting 'percent_threshold_lower' 5 percent, we do not have to write -5.