### PR TITLE
pep8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# Test artifacts #
+##################
+.coverage
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ install:
   - pip install pytest pytest-cov pylama
 
 script: python -m pytest --cov=src/luminol/ src/luminol/tests/
-after_script: python -m pylama -i E501,E402 src/luminol/ || true
+after_script: python -m pylama -i E501,E402,E0602 src/luminol/ || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ install:
   - pip install pytest pytest-cov pylama
 
 script: python -m pytest --cov=src/luminol/ src/luminol/tests/
-after_script: python -m pylama -i E501 src/luminol/ || true
+after_script: python -m pylama -i E501,E402 src/luminol/ || true

--- a/src/luminol/__init__.py
+++ b/src/luminol/__init__.py
@@ -15,36 +15,36 @@ from luminol import exceptions
 
 class Luminol(object):
 
-  def __init__(self, anomalies, correlations):
-    """
-    :param list anomalies: a list of `Anomaly` objects.
-                           `Anomaly` is defined in luminol.modules.anomaly.
+    def __init__(self, anomalies, correlations):
+        """
+        :param list anomalies: a list of `Anomaly` objects.
+                               `Anomaly` is defined in luminol.modules.anomaly.
 
-    :param dict correlations: a dict represents correlated metrics(`TimeSeries` object) to each anomaly.
-                              each key-value pair looks like this:
-                              `Anomaly` --> [metric1, metric2, metric3 ...].
-    """
-    self.anomalies = anomalies
-    self.correlations = correlations
-    self._analyze_root_causes()
+        :param dict correlations: a dict represents correlated metrics(`TimeSeries` object) to each anomaly.
+                                  each key-value pair looks like this:
+                                  `Anomaly` --> [metric1, metric2, metric3 ...].
+        """
+        self.anomalies = anomalies
+        self.correlations = correlations
+        self._analyze_root_causes()
 
-  # TODO(yaguo): Replace this with valid root cause analysis.
-  def _analyze_root_causes(self):
-    """
-    Conduct root cause analysis.
-    The first metric of the list is taken as the root cause right now.
-    """
-    causes = {}
-    for a in self.anomalies:
-      try:
-        causes[a] = self.correlations[a][0]
-      except IndexError:
-        raise exceptions.InvalidDataFormat('luminol.luminol: dict correlations contains empty list.')
-    self.causes = causes
+    # TODO(yaguo): Replace this with valid root cause analysis.
+    def _analyze_root_causes(self):
+        """
+        Conduct root cause analysis.
+        The first metric of the list is taken as the root cause right now.
+        """
+        causes = {}
+        for a in self.anomalies:
+            try:
+                causes[a] = self.correlations[a][0]
+            except IndexError:
+                raise exceptions.InvalidDataFormat('luminol.luminol: dict correlations contains empty list.')
+        self.causes = causes
 
-  def get_root_causes(self):
-    """
-    Get root causes.
-    :return dict: a dict represents root causes for each anomaly.
-    """
-    return getattr(self, 'causes', None)
+    def get_root_causes(self):
+        """
+        Get root causes.
+        :return dict: a dict represents root causes for each anomaly.
+        """
+        return getattr(self, 'causes', None)

--- a/src/luminol/algorithms/anomaly_detector_algorithms/__init__.py
+++ b/src/luminol/algorithms/anomaly_detector_algorithms/__init__.py
@@ -11,8 +11,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
 from luminol.constants import DEFAULT_NOISE_PCT_THRESHOLD
 
-__all__ = ['bitmap_detector', 'derivative_detector', 'exp_avg_detector', 'default_detector', 'absolute_threshold',
-                     'diff_percent_threshold', 'sign_test']
+__all__ = ['bitmap_detector', 'derivative_detector', 'exp_avg_detector',
+           'default_detector', 'absolute_threshold', 'diff_percent_threshold',
+           'sign_test']
 
 
 class AnomalyDetectorAlgorithm(object):

--- a/src/luminol/algorithms/anomaly_detector_algorithms/__init__.py
+++ b/src/luminol/algorithms/anomaly_detector_algorithms/__init__.py
@@ -9,7 +9,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
-from luminol.constants import *
+from luminol.constants import DEFAULT_NOISE_PCT_THRESHOLD
 
 __all__ = ['bitmap_detector', 'derivative_detector', 'exp_avg_detector', 'default_detector', 'absolute_threshold',
                      'diff_percent_threshold', 'sign_test']

--- a/src/luminol/algorithms/anomaly_detector_algorithms/absolute_threshold.py
+++ b/src/luminol/algorithms/anomaly_detector_algorithms/absolute_threshold.py
@@ -10,7 +10,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
 
-from luminol import utils, exceptions
+from luminol import exceptions
 from luminol.algorithms.anomaly_detector_algorithms import AnomalyDetectorAlgorithm
 from luminol.modules.time_series import TimeSeries
 
@@ -20,8 +20,8 @@ class AbsoluteThreshold(AnomalyDetectorAlgorithm):
     Anomalies are those data points that are above a pre-specified threshold value.
     This algorithm does not take baseline time series.
     """
-    def __init__(self, time_series, absolute_threshold_value_upper=None, absolute_threshold_value_lower=None,
-                             baseline_time_series=None):
+    def __init__(self, time_series, absolute_threshold_value_upper=None,
+                 absolute_threshold_value_lower=None, baseline_time_series=None):
         """
         Initialize algorithm, check all required args are present
 
@@ -36,8 +36,8 @@ class AbsoluteThreshold(AnomalyDetectorAlgorithm):
         self.absolute_threshold_value_lower = absolute_threshold_value_lower
         if not self.absolute_threshold_value_lower and not self.absolute_threshold_value_upper:
             raise exceptions.RequiredParametersNotPassed('luminol.algorithms.anomaly_detector_algorithms.absolute_threshold: '
-                                                                                                     'Either absolute_threshold_value_upper or '
-                                                                                                     'absolute_threshold_value_lower needed')
+                                                         'Either absolute_threshold_value_upper or '
+                                                         'absolute_threshold_value_lower needed')
 
     def _set_scores(self):
         """

--- a/src/luminol/algorithms/anomaly_detector_algorithms/absolute_threshold.py
+++ b/src/luminol/algorithms/anomaly_detector_algorithms/absolute_threshold.py
@@ -12,7 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 from luminol import utils, exceptions
 from luminol.algorithms.anomaly_detector_algorithms import AnomalyDetectorAlgorithm
-from luminol.constants import *
 from luminol.modules.time_series import TimeSeries
 
 

--- a/src/luminol/algorithms/anomaly_detector_algorithms/all.py
+++ b/src/luminol/algorithms/anomaly_detector_algorithms/all.py
@@ -10,8 +10,12 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
 from luminol.algorithms.anomaly_detector_algorithms import (bitmap_detector,
-    default_detector, derivative_detector, exp_avg_detector, absolute_threshold,
-    diff_percent_threshold, sign_test)
+                                                            default_detector,
+                                                            derivative_detector,
+                                                            exp_avg_detector,
+                                                            absolute_threshold,
+                                                            diff_percent_threshold,
+                                                            sign_test)
 
 anomaly_detector_algorithms = {
     'bitmap_detector': bitmap_detector.BitmapDetector,

--- a/src/luminol/algorithms/anomaly_detector_algorithms/all.py
+++ b/src/luminol/algorithms/anomaly_detector_algorithms/all.py
@@ -14,11 +14,11 @@ from luminol.algorithms.anomaly_detector_algorithms import (bitmap_detector,
     diff_percent_threshold, sign_test)
 
 anomaly_detector_algorithms = {
-        'bitmap_detector': bitmap_detector.BitmapDetector,
-        'default_detector': default_detector.DefaultDetector,
-        'derivative_detector': derivative_detector.DerivativeDetector,
-        'exp_avg_detector': exp_avg_detector.ExpAvgDetector,
-        'absolute_threshold': absolute_threshold.AbsoluteThreshold,
-        'diff_percent_threshold': diff_percent_threshold.DiffPercentThreshold,
-        'sign_test': sign_test.SignTest
+    'bitmap_detector': bitmap_detector.BitmapDetector,
+    'default_detector': default_detector.DefaultDetector,
+    'derivative_detector': derivative_detector.DerivativeDetector,
+    'exp_avg_detector': exp_avg_detector.ExpAvgDetector,
+    'absolute_threshold': absolute_threshold.AbsoluteThreshold,
+    'diff_percent_threshold': diff_percent_threshold.DiffPercentThreshold,
+    'sign_test': sign_test.SignTest
 }

--- a/src/luminol/algorithms/anomaly_detector_algorithms/all.py
+++ b/src/luminol/algorithms/anomaly_detector_algorithms/all.py
@@ -9,7 +9,9 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
-from luminol.algorithms.anomaly_detector_algorithms import *
+from luminol.algorithms.anomaly_detector_algorithms import (bitmap_detector,
+    default_detector, derivative_detector, exp_avg_detector, absolute_threshold,
+    diff_percent_threshold, sign_test)
 
 anomaly_detector_algorithms = {
         'bitmap_detector': bitmap_detector.BitmapDetector,

--- a/src/luminol/algorithms/anomaly_detector_algorithms/bitmap_detector.py
+++ b/src/luminol/algorithms/anomaly_detector_algorithms/bitmap_detector.py
@@ -33,8 +33,8 @@ class BitmapDetector(AnomalyDetectorAlgorithm):
     The ideas are from this paper:
     Assumption-Free Anomaly Detection in Time Series(http://alumni.cs.ucr.edu/~ratana/SSDBM05.pdf).
     """
-    def __init__(self, time_series, baseline_time_series=None, precision=None, lag_window_size=None,
-        future_window_size=None, chunk_size=None):
+    def __init__(self, time_series, baseline_time_series=None, precision=None,
+                 lag_window_size=None, future_window_size=None, chunk_size=None):
         """
         Initializer
         :param TimeSeries time_series: a TimeSeries object.

--- a/src/luminol/algorithms/anomaly_detector_algorithms/bitmap_detector.py
+++ b/src/luminol/algorithms/anomaly_detector_algorithms/bitmap_detector.py
@@ -15,8 +15,13 @@ import math
 
 from luminol import exceptions
 from luminol.algorithms.anomaly_detector_algorithms import AnomalyDetectorAlgorithm
-from luminol.constants import *
 from luminol.modules.time_series import TimeSeries
+from luminol.constants import (DEFAULT_BITMAP_PRECISION,
+                               DEFAULT_BITMAP_CHUNK_SIZE,
+                               DEFAULT_BITMAP_LAGGING_WINDOW_SIZE_PCT,
+                               DEFAULT_BITMAP_LEADING_WINDOW_SIZE_PCT,
+                               DEFAULT_BITMAP_MINIMAL_POINTS_IN_WINDOWS,
+                               DEFAULT_BITMAP_MAXIMAL_POINTS_IN_WINDOWS)
 
 
 class BitmapDetector(AnomalyDetectorAlgorithm):

--- a/src/luminol/algorithms/anomaly_detector_algorithms/bitmap_detector.py
+++ b/src/luminol/algorithms/anomaly_detector_algorithms/bitmap_detector.py
@@ -62,9 +62,8 @@ class BitmapDetector(AnomalyDetectorAlgorithm):
         Check if there are enough data points.
         """
         windows = self.lag_window_size + self.future_window_size
-        if (not self.lag_window_size or not self.future_window_size
-            or self.time_series_length < windows or windows < DEFAULT_BITMAP_MINIMAL_POINTS_IN_WINDOWS):
-                raise exceptions.NotEnoughDataPoints
+        if (not self.lag_window_size or not self.future_window_size or self.time_series_length < windows or windows < DEFAULT_BITMAP_MINIMAL_POINTS_IN_WINDOWS):
+            raise exceptions.NotEnoughDataPoints
 
         # If window size is too big, too many data points will be assigned a score of 0 in the first lag window
         # and the last future window.

--- a/src/luminol/algorithms/anomaly_detector_algorithms/default_detector.py
+++ b/src/luminol/algorithms/anomaly_detector_algorithms/default_detector.py
@@ -12,8 +12,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 from luminol.algorithms.anomaly_detector_algorithms.exp_avg_detector import ExpAvgDetector
 from luminol.algorithms.anomaly_detector_algorithms.derivative_detector import DerivativeDetector
 from luminol.algorithms.anomaly_detector_algorithms import AnomalyDetectorAlgorithm
-from luminol.constants import *
 from luminol.modules.time_series import TimeSeries
+from luminol.constants import (DEFAULT_DETECTOR_EMA_WEIGHT,
+                               DEFAULT_DETECTOR_EMA_SIGNIFICANT)
 
 
 class DefaultDetector(AnomalyDetectorAlgorithm):

--- a/src/luminol/algorithms/anomaly_detector_algorithms/default_detector.py
+++ b/src/luminol/algorithms/anomaly_detector_algorithms/default_detector.py
@@ -42,7 +42,7 @@ class DefaultDetector(AnomalyDetectorAlgorithm):
         for timestamp in anom_scores_ema.timestamps:
             # Compute a weighted anomaly score.
             anom_scores[timestamp] = max(anom_scores_ema[timestamp],
-                                                                     anom_scores_ema[timestamp] * DEFAULT_DETECTOR_EMA_WEIGHT + anom_scores_deri[timestamp] * (1 - DEFAULT_DETECTOR_EMA_WEIGHT))
+                                         anom_scores_ema[timestamp] * DEFAULT_DETECTOR_EMA_WEIGHT + anom_scores_deri[timestamp] * (1 - DEFAULT_DETECTOR_EMA_WEIGHT))
             # If ema score is significant enough, take the bigger one of the weighted score and deri score.
             if anom_scores_ema[timestamp] > DEFAULT_DETECTOR_EMA_SIGNIFICANT:
                 anom_scores[timestamp] = max(anom_scores[timestamp], anom_scores_deri[timestamp])

--- a/src/luminol/algorithms/anomaly_detector_algorithms/derivative_detector.py
+++ b/src/luminol/algorithms/anomaly_detector_algorithms/derivative_detector.py
@@ -13,7 +13,7 @@ import numpy
 
 from luminol import utils
 from luminol.algorithms.anomaly_detector_algorithms import AnomalyDetectorAlgorithm
-from luminol.constants import *
+from luminol.constants import DEFAULT_DERI_SMOOTHING_FACTOR
 from luminol.modules.time_series import TimeSeries
 
 

--- a/src/luminol/algorithms/anomaly_detector_algorithms/diff_percent_threshold.py
+++ b/src/luminol/algorithms/anomaly_detector_algorithms/diff_percent_threshold.py
@@ -12,7 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 from luminol import exceptions
 from luminol.algorithms.anomaly_detector_algorithms import AnomalyDetectorAlgorithm
-from luminol.constants import *
 from luminol.modules.time_series import TimeSeries
 
 

--- a/src/luminol/algorithms/anomaly_detector_algorithms/exp_avg_detector.py
+++ b/src/luminol/algorithms/anomaly_detector_algorithms/exp_avg_detector.py
@@ -13,8 +13,9 @@ import numpy
 
 from luminol import utils
 from luminol.algorithms.anomaly_detector_algorithms import AnomalyDetectorAlgorithm
-from luminol.constants import *
 from luminol.modules.time_series import TimeSeries
+from luminol.constants import (DEFAULT_EMA_SMOOTHING_FACTOR,
+                               DEFAULT_EMA_WINDOW_SIZE_PCT)
 
 
 class ExpAvgDetector(AnomalyDetectorAlgorithm):

--- a/src/luminol/algorithms/anomaly_detector_algorithms/sign_test.py
+++ b/src/luminol/algorithms/anomaly_detector_algorithms/sign_test.py
@@ -38,11 +38,8 @@ class SignTest(AnomalyDetectorAlgorithm):
      c) the test window must not be larger than the time series
     """
     def __init__(self, time_series, baseline_time_series,
-                             percent_threshold_upper=None,
-                             percent_threshold_lower=None,
-                             offset=0.0,
-                             scan_window=None,
-                             confidence=0.01):
+                 percent_threshold_upper=None, percent_threshold_lower=None,
+                 offset=0.0, scan_window=None, confidence=0.01):
         """
         :param time_series: current time series
         :param baseline_time_series: baseline time series
@@ -93,11 +90,11 @@ class SignTest(AnomalyDetectorAlgorithm):
         scores = np.zeros(len(self.time_series.values))
 
         anomalies = SignTest._rolling_sign_test(self.scale * np.array(self.time_series.values),
-                                                                                        self.scale * np.array(self.baseline_time_series.values),
-                                                                                        k=self.scan_window,
-                                                                                        conf=self.confidence,
-                                                                                        alpha=float(self.percent_threshold) / 100,
-                                                                                        offset=self.scale * self.offset)
+                                                self.scale * np.array(self.baseline_time_series.values),
+                                                k=self.scan_window,
+                                                conf=self.confidence,
+                                                alpha=float(self.percent_threshold) / 100,
+                                                offset=self.scale * self.offset)
         for (s, e), prob in anomalies:
             scores[s:e] = 100 * prob
 

--- a/src/luminol/algorithms/correlator_algorithms/all.py
+++ b/src/luminol/algorithms/correlator_algorithms/all.py
@@ -9,7 +9,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
-from luminol.algorithms.correlator_algorithms import *
+from luminol.algorithms.correlator_algorithms import cross_correlator
 
 correlator_algorithms = {
         'cross_correlator': cross_correlator.CrossCorrelator

--- a/src/luminol/algorithms/correlator_algorithms/cross_correlator.py
+++ b/src/luminol/algorithms/correlator_algorithms/cross_correlator.py
@@ -10,8 +10,9 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
 from luminol.algorithms.correlator_algorithms import CorrelatorAlgorithm
-from luminol.constants import *
 from luminol.modules.correlation_result import CorrelationResult
+from luminol.constants import (DEFAULT_SHIFT_IMPACT,
+                               DEFAULT_ALLOWED_SHIFT_SECONDS)
 
 
 class CrossCorrelator(CorrelatorAlgorithm):

--- a/src/luminol/anomaly_detector.py
+++ b/src/luminol/anomaly_detector.py
@@ -17,9 +17,11 @@ This module detects anomalies in a single time series.
 
 from luminol import exceptions, utils
 from luminol.algorithms.anomaly_detector_algorithms.all import anomaly_detector_algorithms
-from luminol.constants import *
 from luminol.modules.anomaly import Anomaly
 from luminol.modules.time_series import TimeSeries
+from luminol.constants import (ANOMALY_DETECTOR_ALGORITHM, ANOMALY_THRESHOLD,
+                               ANOMALY_DETECTOR_REFINE_ALGORITHM,
+                               DEFAULT_SCORE_PERCENT_THRESHOLD)
 
 
 class AnomalyDetector(object):

--- a/src/luminol/correlator.py
+++ b/src/luminol/correlator.py
@@ -89,7 +89,6 @@ class Correlator(object):
                 self.algorithm_params = self.algorithm_params.copy()
                 self.algorithm_params.update(algorithm_params)
 
-
     def _sanity_check(self):
         """
         Check if the time series have more than two data points.

--- a/src/luminol/correlator.py
+++ b/src/luminol/correlator.py
@@ -17,7 +17,7 @@ This module finds correlation between two time series.
 from luminol import exceptions, utils
 from luminol.algorithms.correlator_algorithms.all import correlator_algorithms
 from luminol.anomaly_detector import AnomalyDetector
-from luminol.constants import *
+from luminol.constants import CORRELATOR_ALGORITHM
 from luminol.modules.time_series import TimeSeries
 
 

--- a/src/luminol/modules/time_series.py
+++ b/src/luminol/modules/time_series.py
@@ -9,7 +9,6 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
-from future.utils import implements_iterator
 import numpy
 
 

--- a/src/luminol/tests/test_anomaly_detector.py
+++ b/src/luminol/tests/test_anomaly_detector.py
@@ -13,14 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import os
 import sys
 import unittest
-import numpy as np
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 from luminol import exceptions
 from luminol.anomaly_detector import AnomalyDetector
 from luminol.modules.time_series import TimeSeries
-from luminol.utils import pbinom, qbinom
 # Needed for custom algorithms
 from luminol.algorithms.anomaly_detector_algorithms import AnomalyDetectorAlgorithm
 

--- a/src/luminol/tests/test_anomaly_detector.py
+++ b/src/luminol/tests/test_anomaly_detector.py
@@ -69,16 +69,16 @@ class TestAnomalyDetector(unittest.TestCase):
                                                   algorithm_name='sign_test'))
         # test over specified
         algorithm_params = {'percent_threshold_upper': 20,
-                          'percent_threshold_lower': -20,
-                          'scan_window': 24,
-                          'confidence': 0.01}
+                            'percent_threshold_lower': -20,
+                            'scan_window': 24,
+                            'confidence': 0.01}
 
         self.assertRaises(exceptions.RequiredParametersNotPassed,
                           lambda: AnomalyDetector(self.s1, baseline_time_series=self.s2,
                                                   algorithm_name='sign_test'))
         # Simple tests
         algorithm_params = {'percent_threshold_upper': 20,
-                          'scan_window': 24}
+                            'scan_window': 24}
 
         # first no anomalies
         detector = AnomalyDetector(ts, baseline_time_series=bs, algorithm_name='sign_test',
@@ -235,7 +235,6 @@ class TestAnomalyDetector(unittest.TestCase):
         self.assertTrue(anomalies is not None)
         self.assertEqual(len(anomalies), 1)
 
-
     def test_sign_test_algorithm_with_shift(self):
         """
         Test "sign test" algorithm with a threshold of 20%
@@ -383,6 +382,7 @@ class TestAnomalyDetector(unittest.TestCase):
         detector1 = AnomalyDetector(self.s1, score_percent_threshold=0.1, algorithm_name='derivative_detector')
         self.assertNotEqual(detector1.get_anomalies(), detector.get_anomalies())
 
+
 class CustomAlgo(AnomalyDetectorAlgorithm):
     """
     Copy of DiffPercentThreshold Algorithm from algorithms/anomaly_detector_algorithms/diff_percent_threshold.py to test
@@ -426,6 +426,7 @@ class CustomAlgo(AnomalyDetectorAlgorithm):
                 anom_scores[timestamp] = -1 * diff_percent
 
         self.anom_scores = TimeSeries(self._denoise_scores(anom_scores))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/luminol/tests/test_correlator.py
+++ b/src/luminol/tests/test_correlator.py
@@ -104,5 +104,6 @@ class TestLuminol(unittest.TestCase):
         self.assertEqual(self.luminol.get_root_causes()['A'], 'm1')
         self.assertEqual(self.luminol.get_root_causes()['B'], 'm2')
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/luminol/tests/test_correlator.py
+++ b/src/luminol/tests/test_correlator.py
@@ -18,9 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 
 from luminol import exceptions
 from luminol import Luminol
-from luminol.anomaly_detector import AnomalyDetector
 from luminol.correlator import Correlator
-from luminol.modules.time_series import TimeSeries
 
 
 class TestCorrelator(unittest.TestCase):

--- a/src/luminol/utils.py
+++ b/src/luminol/utils.py
@@ -21,6 +21,7 @@ from luminol import constants, exceptions
 from scipy.stats import binom
 import sys
 
+
 def compute_ema(smoothing_factor, points):
     """
     Compute exponential moving average of a list of points.

--- a/src/luminol/utils.py
+++ b/src/luminol/utils.py
@@ -72,12 +72,12 @@ def to_epoch(t_str):
     try:
         t = float(t_str)
         return t
-    except:
+    except ValueError:
         for format in constants.TIMESTAMP_STR_FORMATS:
             try:
                 t = datetime.datetime.strptime(t_str, format)
                 return float(time.mktime(t.utctimetuple()) * 1000.0 + t.microsecond / 1000.0)
-            except:
+            except ValueError:
                 pass
     raise exceptions.InvalidDataFormat
 


### PR DESCRIPTION
Any time when suggesting pep8 changes we are reminded of [this](https://www.python.org/dev/peps/pep-0008/#a-foolish-consistency-is-the-hobgoblin-of-little-minds). With that in mind, I'd like to suggest some aesthetic changes for convention and maintainability. In our Travis runs we check pep8 compliance as the last step. The last results before this PR are shown here:

[https://travis-ci.org/linkedin/luminol/jobs/273116296#L663](https://travis-ci.org/linkedin/luminol/jobs/273116296#L663)

This first commit serves only to make imports more explicit. It resolves all the warnings that read: `W0401 'from luminol.constants import *' used; unable to detect undefined names [pyflakes]`

I'd like to add additional commits to this PR if folks are open to it.