### PR TITLE
Import anomaly_detector and correlator into luminol

### DIFF
--- a/src/luminol/__init__.py
+++ b/src/luminol/__init__.py
@@ -10,6 +10,10 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
 
+
+import luminol.anomaly_detector 
+import luminol.correlator
+
 from luminol import exceptions
 
 


### PR DESCRIPTION
With this, the example from README works. 

In other words with proposed change one can `import luminol` and later `detector = luminol.anomaly_detector.AnomalyDetector(ts)`, currently `anomaly_detector` is not visible as a member of `luminol` module.